### PR TITLE
[WIP] Add semantic convention for specification 1.4.0

### DIFF
--- a/semconv/v1_4_0/doc.go
+++ b/semconv/v1_4_0/doc.go
@@ -1,0 +1,52 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package semconv implements OpenTelemetry semantic conventions start from specification
+// version 1.4.0 and until the next version that introduced any changes.
+//
+// This package is currently in a pre-GA phase. Backwards incompatible changes
+// may be introduced in subsequent minor version releases as we work to track
+// the evolving OpenTelemetry specification and user feedback.
+//
+// OpenTelemetry semantic conventions are agreed standardized naming
+// patterns for OpenTelemetry things. This package aims to be the
+// centralized place to interact with these conventions.
+//
+// Example usage:
+//
+//  import semconv "go.opentelemetry.io/otel/semconv/v1_4_0"
+//  ...
+//  // Get a Tracer associcated with the Schema URL matching the semantic conventions
+//  // that we want to use.
+//	tracer := provider.Tracer("example_library", trace.WithSchemaURL(semconv.SchemaURL))
+//	...
+//  // Crate a Span.
+//	var span trace.Span
+//	_, span = tracer.Start(
+//		context.Background(),
+//		"operation",
+//		// Note that here we use the semantic conventon for HostName that matches
+//		// the Schema URL that we used in the Tracer() call.
+//		trace.WithAttributes(semconv.HostNameKey.String("example.com")),
+//	)
+//	span.End()
+//
+package v1_4_0
+
+// Note: semantic conventions are immutable. They can only change if a new specification
+// version is introduced. If you need to change a semantic convention definition in this
+// package it means there is a new specification version that introduced the change.
+// In that case copy this package, give it a new name that corresponds to the new version
+// number and modify the semantic convention definitions.
+// Important: make sure to update SchemaURL string correspondingly.

--- a/semconv/v1_4_0/exception.go
+++ b/semconv/v1_4_0/exception.go
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package v1_4_0
+
+import (
+	"go.opentelemetry.io/otel/semconv"
+)
+
+// Semantic conventions for exception attribute keys.
+const (
+	// The Go type containing the error or exception.
+	ExceptionTypeKey = semconv.ExceptionEscapedKey
+
+	// The exception message.
+	ExceptionMessageKey = semconv.ExceptionMessageKey
+
+	// A stacktrace as a string. This most commonly will come from
+	// "runtime/debug".Stack.
+	ExceptionStacktraceKey = semconv.ExceptionStacktraceKey
+
+	// If the exception event is recorded at a point where it is known
+	// that the exception is escaping the scope of the span this
+	// attribute is set to true.
+	ExceptionEscapedKey = semconv.ExceptionEscapedKey
+)
+
+const (
+	// ExceptionEventName is the name of the Span event representing an exception.
+	ExceptionEventName = semconv.ExceptionEventName
+)

--- a/semconv/v1_4_0/http.go
+++ b/semconv/v1_4_0/http.go
@@ -1,0 +1,51 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_4_0
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/semconv"
+)
+
+func NetAttributesFromHTTPRequest(network string, request *http.Request) []attribute.KeyValue {
+	return semconv.NetAttributesFromHTTPRequest(network, request)
+}
+
+func EndUserAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	return semconv.EndUserAttributesFromHTTPRequest(request)
+}
+
+func HTTPClientAttributesFromHTTPRequest(request *http.Request) []attribute.KeyValue {
+	return semconv.HTTPClientAttributesFromHTTPRequest(request)
+}
+
+func HTTPServerMetricAttributesFromHTTPRequest(serverName string, request *http.Request) []attribute.KeyValue {
+	return semconv.HTTPServerMetricAttributesFromHTTPRequest(serverName, request)
+}
+
+func HTTPServerAttributesFromHTTPRequest(serverName, route string, request *http.Request) []attribute.KeyValue {
+	return semconv.HTTPServerAttributesFromHTTPRequest(serverName, route, request)
+}
+
+func HTTPAttributesFromHTTPStatusCode(code int) []attribute.KeyValue {
+	return semconv.HTTPAttributesFromHTTPStatusCode(code)
+}
+
+func SpanStatusFromHTTPStatusCode(code int) (codes.Code, string) {
+	return semconv.SpanStatusFromHTTPStatusCode(code)
+}

--- a/semconv/v1_4_0/resource.go
+++ b/semconv/v1_4_0/resource.go
@@ -1,0 +1,263 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_4_0
+
+import (
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/semconv"
+)
+
+// Semantic conventions for service resource attribute keys.
+const (
+	// Name of the service.
+	ServiceNameKey = semconv.ServiceNameKey
+
+	// A namespace for `service.name`. This needs to have meaning that helps
+	// to distinguish a group of services. For example, the team name that
+	// owns a group of services. `service.name` is expected to be unique
+	// within the same namespace.
+	//
+	// [Modified in 1.4.0]. TODO: revert this change, it is done for illustration only,
+	// in reality the convention for Service Namespace has not changed in 1.4.0.
+	ServiceNamespaceKey = attribute.Key("service.namespace.name")
+
+	// A unique identifier of the service instance. In conjunction with the
+	// `service.name` and `service.namespace` this must be unique.
+	ServiceInstanceIDKey = semconv.ServiceInstanceIDKey
+
+	// The version of the service API.
+	ServiceVersionKey = semconv.ServiceVersionKey
+)
+
+// Semantic conventions for telemetry SDK resource attribute keys.
+const (
+	// The name of the telemetry SDK.
+	//
+	// The default OpenTelemetry SDK provided by the OpenTelemetry project
+	// MUST set telemetry.sdk.name to the value `opentelemetry`.
+	//
+	// If another SDK is used, this attribute MUST be set to the import path
+	// of that SDK's package.
+	//
+	// The value `opentelemetry` is reserved and MUST NOT be used by
+	// non-OpenTelemetry SDKs.
+	TelemetrySDKNameKey = semconv.TelemetrySDKNameKey
+
+	// The language of the telemetry SDK.
+	TelemetrySDKLanguageKey = semconv.TelemetrySDKLanguageKey
+
+	// The version string of the telemetry SDK.
+	TelemetrySDKVersionKey = semconv.TelemetrySDKVersionKey
+)
+
+// Semantic conventions for telemetry SDK resource attributes.
+var (
+	TelemetrySDKLanguageGo = semconv.TelemetrySDKLanguageGo
+)
+
+// Semantic conventions for container resource attribute keys.
+const (
+	// A uniquely identifying name for the Container.
+	ContainerNameKey = semconv.ContainerNameKey
+
+	// Container ID, usually a UUID, as for example used to
+	// identify Docker containers. The UUID might be abbreviated.
+	ContainerIDKey = semconv.ContainerIDKey
+
+	// Name of the image the container was built on.
+	ContainerImageNameKey = semconv.ContainerImageNameKey
+
+	// Container image tag.
+	ContainerImageTagKey = semconv.ContainerImageTagKey
+)
+
+// Semantic conventions for Function-as-a-Service resource attribute keys.
+const (
+	// A uniquely identifying name for the FaaS.
+	FaaSNameKey = semconv.FaaSNameKey
+
+	// The unique name of the function being executed.
+	FaaSIDKey = semconv.FaaSIDKey
+
+	// The version of the function being executed.
+	FaaSVersionKey = semconv.FaaSVersionKey
+
+	// The execution environment identifier.
+	FaaSInstanceKey = semconv.FaaSInstanceKey
+)
+
+// Semantic conventions for operating system process resource attribute keys.
+const (
+	// Process identifier (PID).
+	ProcessPIDKey = semconv.ProcessPIDKey
+	// The name of the process executable. On Linux based systems, can be
+	// set to the `Name` in `proc/[pid]/status`. On Windows, can be set to
+	// the base name of `GetProcessImageFileNameW`.
+	ProcessExecutableNameKey = semconv.ProcessExecutableNameKey
+	// The full path to the process executable. On Linux based systems, can
+	// be set to the target of `proc/[pid]/exe`. On Windows, can be set to
+	// the result of `GetProcessImageFileNameW`.
+	ProcessExecutablePathKey = semconv.ProcessExecutablePathKey
+	// The command used to launch the process (i.e. the command name). On
+	// Linux based systems, can be set to the zeroth string in
+	// `proc/[pid]/cmdline`. On Windows, can be set to the first parameter
+	// extracted from `GetCommandLineW`.
+	ProcessCommandKey = semconv.ProcessCommandKey
+	// The full command used to launch the process. The value can be either
+	// a list of strings representing the ordered list of arguments, or a
+	// single string representing the full command. On Linux based systems,
+	// can be set to the list of null-delimited strings extracted from
+	// `proc/[pid]/cmdline`. On Windows, can be set to the result of
+	// `GetCommandLineW`.
+	ProcessCommandLineKey = semconv.ProcessCommandLineKey
+	// All the command arguments (including the command/executable itself)
+	// as received by the process. On Linux-based systems (and some other
+	// Unixoid systems supporting procfs), can be set according to the list
+	// of null-delimited strings extracted from `proc/[pid]/cmdline`. For
+	// libc-based executables, this would be the full argv vector passed to
+	// `main`.
+	ProcessCommandArgsKey = semconv.ProcessCommandArgsKey
+	// The username of the user that owns the process.
+	ProcessOwnerKey = semconv.ProcessOwnerKey
+	// The name of the runtime of this process. For compiled native
+	// binaries, this SHOULD be the name of the compiler.
+	ProcessRuntimeNameKey = semconv.ProcessRuntimeNameKey
+	// The version of the runtime of this process, as returned by the
+	// runtime without modification.
+	ProcessRuntimeVersionKey = semconv.ProcessRuntimeVersionKey
+	// An additional description about the runtime of the process, for
+	// example a specific vendor customization of the runtime environment.
+	ProcessRuntimeDescriptionKey = semconv.ProcessRuntimeDescriptionKey
+)
+
+// Semantic conventions for Kubernetes resource attribute keys.
+const (
+	// A uniquely identifying name for the Kubernetes cluster. Kubernetes
+	// does not have cluster names as an internal concept so this may be
+	// set to any meaningful value within the environment. For example,
+	// GKE clusters have a name which can be used for this attribute.
+	K8SClusterNameKey = semconv.K8SClusterNameKey
+
+	// The name of the Node.
+	K8SNodeNameKey = semconv.K8SNodeNameKey
+
+	// The UID of the Node.
+	K8SNodeUIDKey = semconv.K8SNodeUIDKey
+
+	// The name of the namespace that the pod is running in.
+	K8SNamespaceNameKey = semconv.K8SNamespaceNameKey
+
+	// The uid of the Pod.
+	K8SPodUIDKey = semconv.K8SPodUIDKey
+
+	// The name of the pod.
+	K8SPodNameKey = semconv.K8SPodNameKey
+
+	// The name of the Container in a Pod template.
+	K8SContainerNameKey = semconv.K8SContainerNameKey
+
+	// The uid of the ReplicaSet.
+	K8SReplicaSetUIDKey = semconv.K8SReplicaSetUIDKey
+
+	// The name of the ReplicaSet.
+	K8SReplicaSetNameKey = semconv.K8SReplicaSetNameKey
+
+	// The uid of the Deployment.
+	K8SDeploymentUIDKey = semconv.K8SDeploymentUIDKey
+
+	// The name of the deployment.
+	K8SDeploymentNameKey = semconv.K8SDeploymentNameKey
+
+	// The uid of the StatefulSet.
+	K8SStatefulSetUIDKey = semconv.K8SStatefulSetUIDKey
+
+	// The name of the StatefulSet.
+	K8SStatefulSetNameKey = semconv.K8SStatefulSetNameKey
+
+	// The uid of the DaemonSet.
+	K8SDaemonSetUIDKey = semconv.K8SDaemonSetUIDKey
+
+	// The name of the DaemonSet.
+	K8SDaemonSetNameKey = semconv.K8SDaemonSetNameKey
+
+	// The uid of the Job.
+	K8SJobUIDKey = semconv.K8SJobUIDKey
+
+	// The name of the Job.
+	K8SJobNameKey = semconv.K8SJobNameKey
+
+	// The uid of the CronJob.
+	K8SCronJobUIDKey = semconv.K8SCronJobUIDKey
+
+	// The name of the CronJob.
+	K8SCronJobNameKey = semconv.K8SCronJobNameKey
+)
+
+// Semantic conventions for OS resource attribute keys.
+const (
+	// The operating system type.
+	OSTypeKey = semconv.OSTypeKey
+	// Human readable (not intended to be parsed) OS version information.
+	OSDescriptionKey = semconv.OSDescriptionKey
+)
+
+// Semantic conventions for host resource attribute keys.
+const (
+	// A uniquely identifying name for the host: 'hostname', FQDN, or user specified name
+	HostNameKey = semconv.HostNameKey
+
+	// Unique host ID. For cloud environments this will be the instance ID.
+	HostIDKey = semconv.HostIDKey
+
+	// Type of host. For cloud environments this will be the machine type.
+	HostTypeKey = semconv.HostTypeKey
+
+	// Name of the OS or VM image the host is running.
+	HostImageNameKey = semconv.HostImageNameKey
+
+	// Identifier of the image the host is running.
+	HostImageIDKey = semconv.HostImageIDKey
+
+	// Version of the image the host is running.
+	HostImageVersionKey = semconv.HostImageVersionKey
+)
+
+// Semantic conventions for cloud environment resource attribute keys.
+const (
+	// Name of the cloud provider.
+	CloudProviderKey = semconv.CloudProviderKey
+
+	// The account ID from the cloud provider used for authorization.
+	CloudAccountIDKey = semconv.CloudAccountIDKey
+
+	// Geographical region where this resource is.
+	CloudRegionKey = semconv.CloudRegionKey
+
+	// Availability zone of the region where this resource is.
+	CloudAvailabilityZoneKey = semconv.CloudAvailabilityZoneKey
+)
+
+// Semantic conventions for common cloud provider resource attributes.
+var (
+	CloudProviderAWS   = semconv.CloudProviderAWS
+	CloudProviderAzure = semconv.CloudProviderAzure
+	CloudProviderGCP   = semconv.CloudProviderGCP
+)
+
+// Semantic conventions for deployment attributes.
+const (
+	// Name of the deployment environment (aka deployment tier); e.g. (staging, production).
+	DeploymentEnvironmentKey = semconv.DeploymentEnvironmentKey
+)

--- a/semconv/v1_4_0/schema.go
+++ b/semconv/v1_4_0/schema.go
@@ -1,0 +1,3 @@
+package v1_4_0
+
+const SchemaURL = "https://opentelemetry.io/schemas/1.4.0"

--- a/semconv/v1_4_0/trace.go
+++ b/semconv/v1_4_0/trace.go
@@ -1,0 +1,378 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1_4_0
+
+import (
+	"go.opentelemetry.io/otel/semconv"
+)
+
+// Semantic conventions for attribute keys used for network related
+// operations.
+const (
+	// Transport protocol used.
+	NetTransportKey = semconv.NetTransportKey
+
+	// Remote address of the peer.
+	NetPeerIPKey = semconv.NetPeerIPKey
+
+	// Remote port number.
+	NetPeerPortKey = semconv.NetPeerPortKey
+
+	// Remote hostname or similar.
+	NetPeerNameKey = semconv.NetPeerNameKey
+
+	// Local host IP. Useful in case of a multi-IP host.
+	NetHostIPKey = semconv.NetHostIPKey
+
+	// Local host port.
+	NetHostPortKey = semconv.NetHostPortKey
+
+	// Local hostname or similar.
+	NetHostNameKey = semconv.NetHostNameKey
+)
+
+// Semantic conventions for common transport protocol attributes.
+var (
+	NetTransportTCP    = semconv.NetTransportTCP
+	NetTransportUDP    = semconv.NetTransportUDP
+	NetTransportIP     = semconv.NetTransportIP
+	NetTransportUnix   = semconv.NetTransportUnix
+	NetTransportPipe   = semconv.NetTransportPipe
+	NetTransportInProc = semconv.NetTransportInProc
+	NetTransportOther  = semconv.NetTransportOther
+)
+
+// General attribute keys for spans.
+const (
+	// Service name of the remote service. Should equal the actual
+	// `service.name` resource attribute of the remote service, if any.
+	PeerServiceKey = semconv.PeerServiceKey
+)
+
+// Semantic conventions for attribute keys used to identify an authorized
+// user.
+const (
+	// Username or the client identifier extracted from the access token or
+	// authorization header in the inbound request from outside the system.
+	EnduserIDKey = semconv.EnduserIDKey
+
+	// Actual or assumed role the client is making the request with.
+	EnduserRoleKey = semconv.EnduserRoleKey
+
+	// Scopes or granted authorities the client currently possesses.
+	EnduserScopeKey = semconv.EnduserScopeKey
+)
+
+// Semantic conventions for attribute keys for HTTP.
+const (
+	// HTTP request method.
+	HTTPMethodKey = semconv.HTTPMethodKey
+
+	// Full HTTP request URL in the form:
+	// scheme://host[:port]/path?query[#fragment].
+	HTTPURLKey = semconv.HTTPURLKey
+
+	// The full request target as passed in a HTTP request line or
+	// equivalent, e.g. "/path/12314/?q=ddds#123".
+	HTTPTargetKey = semconv.HTTPTargetKey
+
+	// The value of the HTTP host header.
+	HTTPHostKey = semconv.HTTPHostKey
+
+	// The URI scheme identifying the used protocol.
+	HTTPSchemeKey = semconv.HTTPSchemeKey
+
+	// HTTP response status code.
+	HTTPStatusCodeKey = semconv.HTTPStatusCodeKey
+
+	// Kind of HTTP protocol used.
+	HTTPFlavorKey = semconv.HTTPFlavorKey
+
+	// Value of the HTTP User-Agent header sent by the client.
+	HTTPUserAgentKey = semconv.HTTPUserAgentKey
+
+	// The primary server name of the matched virtual host.
+	HTTPServerNameKey = semconv.HTTPServerNameKey
+
+	// The matched route served (path template). For example,
+	// "/users/:userID?".
+	HTTPRouteKey = semconv.HTTPRouteKey
+
+	// The IP address of the original client behind all proxies, if known
+	// (e.g. from X-Forwarded-For).
+	HTTPClientIPKey = semconv.HTTPClientIPKey
+
+	// The size of the request payload body in bytes.
+	HTTPRequestContentLengthKey = semconv.HTTPRequestContentLengthKey
+
+	// The size of the uncompressed request payload body after transport decoding.
+	// Not set if transport encoding not used.
+	HTTPRequestContentLengthUncompressedKey = semconv.HTTPRequestContentLengthUncompressedKey
+
+	// The size of the response payload body in bytes.
+	HTTPResponseContentLengthKey = semconv.HTTPResponseContentLengthKey
+
+	// The size of the uncompressed response payload body after transport decoding.
+	// Not set if transport encoding not used.
+	HTTPResponseContentLengthUncompressedKey = semconv.HTTPResponseContentLengthUncompressedKey
+)
+
+// Semantic conventions for common HTTP attributes.
+var (
+	// Semantic conventions for HTTP(S) URI schemes.
+	HTTPSchemeHTTP  = semconv.HTTPSchemeHTTP
+	HTTPSchemeHTTPS = semconv.HTTPSchemeHTTPS
+
+	// Semantic conventions for HTTP protocols.
+	HTTPFlavor1_0  = semconv.HTTPFlavor1_0
+	HTTPFlavor1_1  = semconv.HTTPFlavor1_1
+	HTTPFlavor2    = semconv.HTTPFlavor2
+	HTTPFlavorSPDY = semconv.HTTPFlavorSPDY
+	HTTPFlavorQUIC = semconv.HTTPFlavorQUIC
+)
+
+// Semantic conventions for attribute keys for database connections.
+const (
+	// Identifier for the database system (DBMS) being used.
+	DBSystemKey = semconv.DBSystemKey
+
+	// Database Connection String with embedded credentials removed.
+	DBConnectionStringKey = semconv.DBConnectionStringKey
+
+	// Username for accessing database.
+	DBUserKey = semconv.DBUserKey
+)
+
+// Semantic conventions for common database system attributes.
+var (
+	DBSystemDB2       = semconv.DBSystemDB2
+	DBSystemDerby     = semconv.DBSystemDerby
+	DBSystemHive      = semconv.DBSystemHive
+	DBSystemMariaDB   = semconv.DBSystemMariaDB
+	DBSystemMSSql     = semconv.DBSystemMSSql
+	DBSystemMySQL     = semconv.DBSystemMySQL
+	DBSystemOracle    = semconv.DBSystemOracle
+	DBSystemPostgres  = semconv.DBSystemPostgres
+	DBSystemSqlite    = semconv.DBSystemSqlite
+	DBSystemTeradata  = semconv.DBSystemTeradata
+	DBSystemOtherSQL  = semconv.DBSystemOtherSQL
+	DBSystemCassandra = semconv.DBSystemCassandra
+	DBSystemCosmosDB  = semconv.DBSystemCosmosDB
+	DBSystemCouchbase = semconv.DBSystemCouchbase
+	DBSystemCouchDB   = semconv.DBSystemCouchDB
+	DBSystemDynamoDB  = semconv.DBSystemDynamoDB
+	DBSystemHBase     = semconv.DBSystemHBase
+	DBSystemMongodb   = semconv.DBSystemMongodb
+	DBSystemNeo4j     = semconv.DBSystemNeo4j
+	DBSystemRedis     = semconv.DBSystemRedis
+)
+
+// Semantic conventions for attribute keys for database calls.
+const (
+	// Database instance name.
+	DBNameKey = semconv.DBNameKey
+
+	// A database statement for the given database type.
+	DBStatementKey = semconv.DBStatementKey
+
+	// A database operation for the given database type.
+	DBOperationKey = semconv.DBOperationKey
+)
+
+// Database technology-specific attributes
+const (
+	// Name of the Cassandra keyspace accessed. Use instead of `db.name`.
+	DBCassandraKeyspaceKey = semconv.DBCassandraKeyspaceKey
+
+	// HBase namespace accessed. Use instead of `db.name`.
+	DBHBaseNamespaceKey = semconv.DBHBaseNamespaceKey
+
+	// Index of Redis database accessed. Use instead of `db.name`.
+	DBRedisDBIndexKey = semconv.DBRedisDBIndexKey
+
+	// Collection being accessed within the database in `db.name`.
+	DBMongoDBCollectionKey = semconv.DBMongoDBCollectionKey
+)
+
+// Semantic conventions for attribute keys for RPC.
+const (
+	// A string identifying the remoting system.
+	RPCSystemKey = semconv.RPCSystemKey
+
+	// The full name of the service being called.
+	RPCServiceKey = semconv.RPCServiceKey
+
+	// The name of the method being called.
+	RPCMethodKey = semconv.RPCMethodKey
+
+	// Name of message transmitted or received.
+	RPCNameKey = semconv.RPCNameKey
+
+	// Type of message transmitted or received.
+	RPCMessageTypeKey = semconv.RPCMessageTypeKey
+
+	// Identifier of message transmitted or received.
+	RPCMessageIDKey = semconv.RPCMessageIDKey
+
+	// The compressed size of the message transmitted or received in bytes.
+	RPCMessageCompressedSizeKey = semconv.RPCMessageCompressedSizeKey
+
+	// The uncompressed size of the message transmitted or received in
+	// bytes.
+	RPCMessageUncompressedSizeKey = semconv.RPCMessageUncompressedSizeKey
+)
+
+// Semantic conventions for common RPC attributes.
+var (
+	// Semantic convention for gRPC as the remoting system.
+	RPCSystemGRPC = semconv.RPCSystemGRPC
+
+	// Semantic convention for a message named message.
+	RPCNameMessage = semconv.RPCNameMessage
+
+	// Semantic conventions for RPC message types.
+	RPCMessageTypeSent     = semconv.RPCMessageTypeSent
+	RPCMessageTypeReceived = semconv.RPCMessageTypeReceived
+)
+
+// Semantic conventions for attribute keys for messaging systems.
+const (
+	// A unique identifier describing the messaging system. For example,
+	// kafka, rabbitmq or activemq.
+	MessagingSystemKey = semconv.MessagingSystemKey
+
+	// The message destination name, e.g. MyQueue or MyTopic.
+	MessagingDestinationKey = semconv.MessagingDestinationKey
+
+	// The kind of message destination.
+	MessagingDestinationKindKey = semconv.MessagingDestinationKindKey
+
+	// Describes if the destination is temporary or not.
+	MessagingTempDestinationKey = semconv.MessagingTempDestinationKey
+
+	// The name of the transport protocol.
+	MessagingProtocolKey = semconv.MessagingProtocolKey
+
+	// The version of the transport protocol.
+	MessagingProtocolVersionKey = semconv.MessagingProtocolVersionKey
+
+	// Messaging service URL.
+	MessagingURLKey = semconv.MessagingURLKey
+
+	// Identifier used by the messaging system for a message.
+	MessagingMessageIDKey = semconv.MessagingMessageIDKey
+
+	// Identifier used by the messaging system for a conversation.
+	MessagingConversationIDKey = semconv.MessagingConversationIDKey
+
+	// The (uncompressed) size of the message payload in bytes.
+	MessagingMessagePayloadSizeBytesKey = semconv.MessagingMessagePayloadSizeBytesKey
+
+	// The compressed size of the message payload in bytes.
+	MessagingMessagePayloadCompressedSizeBytesKey = semconv.MessagingMessagePayloadCompressedSizeBytesKey
+
+	// Identifies which part and kind of message consumption is being
+	// preformed.
+	MessagingOperationKey = semconv.MessagingOperationKey
+
+	// RabbitMQ specific attribute describing the destination routing key.
+	MessagingRabbitMQRoutingKeyKey = semconv.MessagingRabbitMQRoutingKeyKey
+)
+
+// Semantic conventions for common messaging system attributes.
+var (
+	// Semantic conventions for message destinations.
+	MessagingDestinationKindKeyQueue = semconv.MessagingDestinationKindKeyQueue
+	MessagingDestinationKindKeyTopic = semconv.MessagingDestinationKindKeyTopic
+
+	// Semantic convention for message destinations that are temporary.
+	MessagingTempDestination = semconv.MessagingTempDestination
+
+	// Semantic convention for the operation parts of message consumption.
+	// This does not include a "send" attribute as that is explicitly not
+	// allowed in the OpenTelemetry specification.
+	MessagingOperationReceive = semconv.MessagingOperationReceive
+	MessagingOperationProcess = semconv.MessagingOperationProcess
+)
+
+// Semantic conventions for attribute keys for FaaS systems.
+const (
+
+	// Type of the trigger on which the function is executed.
+	FaaSTriggerKey = semconv.FaaSTriggerKey
+
+	// String containing the execution identifier of the function.
+	FaaSExecutionKey = semconv.FaaSExecutionKey
+
+	// A boolean indicating that the serverless function is executed
+	// for the first time (aka cold start).
+	FaaSColdstartKey = semconv.FaaSColdstartKey
+
+	// The name of the source on which the operation was performed.
+	// For example, in Cloud Storage or S3 corresponds to the bucket name,
+	// and in Cosmos DB to the database name.
+	FaaSDocumentCollectionKey = semconv.FaaSDocumentCollectionKey
+
+	// The type of the operation that was performed on the data.
+	FaaSDocumentOperationKey = semconv.FaaSDocumentOperationKey
+
+	// A string containing the time when the data was accessed.
+	FaaSDocumentTimeKey = semconv.FaaSDocumentTimeKey
+
+	// The document name/table subjected to the operation.
+	FaaSDocumentNameKey = semconv.FaaSDocumentNameKey
+
+	// The function invocation time.
+	FaaSTimeKey = semconv.FaaSTimeKey
+
+	// The schedule period as Cron Expression.
+	FaaSCronKey = semconv.FaaSCronKey
+)
+
+// Semantic conventions for common FaaS system attributes.
+var (
+	// Semantic conventions for the types of triggers.
+	FaasTriggerDatasource = semconv.FaasTriggerDatasource
+	FaasTriggerHTTP       = semconv.FaasTriggerHTTP
+	FaasTriggerPubSub     = semconv.FaasTriggerPubSub
+	FaasTriggerTimer      = semconv.FaasTriggerTimer
+	FaasTriggerOther      = semconv.FaasTriggerOther
+
+	// Semantic conventions for the types of operations performed.
+	FaaSDocumentOperationInsert = semconv.FaaSDocumentOperationInsert
+	FaaSDocumentOperationEdit   = semconv.FaaSDocumentOperationEdit
+	FaaSDocumentOperationDelete = semconv.FaaSDocumentOperationDelete
+)
+
+// Semantic conventions for source code attributes.
+const (
+	// The method or function name, or equivalent (usually rightmost part of
+	// the code unit's name).
+	CodeFunctionKey = semconv.CodeFunctionKey
+
+	// The "namespace" within which `code.function` is defined. Usually the
+	// qualified class or module name, such that
+	// `code.namespace` + some separator + `code.function` form a unique
+	// identifier for the code unit.
+	CodeNamespaceKey = semconv.CodeNamespaceKey
+
+	// The source code file name that identifies the code unit as uniquely as
+	// possible (preferably an absolute file path).
+	CodeFilepathKey = semconv.CodeFilepathKey
+
+	// The line number in `code.filepath` best representing the operation.
+	// It SHOULD point within the code unit named in `code.function`.
+	CodeLineNumberKey = semconv.CodeLineNumberKey
+)


### PR DESCRIPTION
[This is a draft. Do not merge.]

I suggest to use separate packages for each version of the semantic conventions
that has an changes since the last defined package.

The semantic convention package includes semantic convention definitions, most of
which will typically be aliases of semantic conventions of the last defined package,
and perhaps include some changed semantic convention definitions, plus the schema URL
constant that matches the version of the semantic conventions.

Individual instrumentation libraries are supposed to import and use one and only one
semantic convention package (although different libraries used in one application
may import different semantic convention packages).